### PR TITLE
Warn and ban actions

### DIFF
--- a/actions/ban.js
+++ b/actions/ban.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const emitter = require('./emitter');
+
+const { telegram } = require('../bot');
+
+const { listGroups } = require('../stores/group');
+const { ban } = require('../stores/user');
+
+
+module.exports = async (userToBan, reason) => {
+	// move some checks from handler here?
+
+	await ban(userToBan, reason);
+
+	const groups = await listGroups();
+
+	groups.forEach(group =>
+		telegram.kickChatMember(group.id, userToBan.id));
+
+	emitter.emit('ban', userToBan, reason);
+
+	// return something useful?
+};

--- a/actions/ban.js
+++ b/actions/ban.js
@@ -13,7 +13,7 @@ const displayUser = user =>
 		? link(user)
 		: `an user with id <code>${user.id}</code>`;
 
-module.exports = async (admin, userToBan, reason) => {
+module.exports = async ({ admin, userToBan, reason }) => {
 	// move some checks from handler here?
 
 	await ban(userToBan, reason);

--- a/actions/ban.js
+++ b/actions/ban.js
@@ -1,12 +1,19 @@
 'use strict';
 
+const dedent = require('dedent-js');
+
 const { telegram } = require('../bot');
+const { link } = require('../utils/tg');
 
 const { listGroups } = require('../stores/group');
 const { ban } = require('../stores/user');
 
+const displayUser = user =>
+	user.first_name
+		? link(user)
+		: `an user with id <code>${user.id}</code>`;
 
-module.exports = async (userToBan, reason) => {
+module.exports = async (admin, userToBan, reason) => {
 	// move some checks from handler here?
 
 	await ban(userToBan, reason);
@@ -16,5 +23,8 @@ module.exports = async (userToBan, reason) => {
 	groups.forEach(group =>
 		telegram.kickChatMember(group.id, userToBan.id));
 
-	// return something useful?
+	return dedent(`
+		🚫 ${link(admin)} <b>banned</b> ${displayUser(userToBan)} <b>for:</b>
+
+		${reason}`);
 };

--- a/actions/ban.js
+++ b/actions/ban.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const emitter = require('./emitter');
-
 const { telegram } = require('../bot');
 
 const { listGroups } = require('../stores/group');
@@ -17,8 +15,6 @@ module.exports = async (userToBan, reason) => {
 
 	groups.forEach(group =>
 		telegram.kickChatMember(group.id, userToBan.id));
-
-	emitter.emit('ban', userToBan, reason);
 
 	// return something useful?
 };

--- a/actions/emitter.js
+++ b/actions/emitter.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const Emitter = require('events');
+
+module.exports = new Emitter();

--- a/actions/emitter.js
+++ b/actions/emitter.js
@@ -1,5 +1,0 @@
-'use strict';
-
-const Emitter = require('events');
-
-module.exports = new Emitter();

--- a/actions/warn.js
+++ b/actions/warn.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const dedent = require('dedent-js');
+
+const { context } = require('../bot');
+const { link } = require('../utils/tg');
+const { numberOfWarnsToBan } = require('../config');
+const { warn } = require('../stores/user');
+const ban = require('./ban');
+
+
+module.exports = async (admin, userToWarn, reason) => {
+	const { warns } = await warn(userToWarn, reason);
+
+	const replies = [
+		dedent(`⚠️ ${link(admin)} <b>warned</b> ${link(userToWarn)} <b>for</b>:
+
+		${reason} (${warns.length}/${numberOfWarnsToBan})`),
+	];
+
+	if (warns.length >= numberOfWarnsToBan) {
+		replies.push(await ban(
+			context.botInfo,
+			userToWarn,
+			'Reached max number of warnings'
+		));
+	}
+
+	return replies;
+};

--- a/actions/warn.js
+++ b/actions/warn.js
@@ -13,8 +13,8 @@ module.exports = async (admin, userToWarn, reason) => {
 	const { warns } = await warn(userToWarn, reason);
 
 
-	const warnMessage =
-		dedent(`⚠️ ${link(admin)} <b>warned</b> ${link(userToWarn)} <b>for</b>:
+	const warnMessage = dedent(`
+		⚠️ ${link(admin)} <b>warned</b> ${link(userToWarn)} <b>for</b>:
 
 		${reason} (${warns.length}/${numberOfWarnsToBan})`);
 

--- a/actions/warn.js
+++ b/actions/warn.js
@@ -12,11 +12,13 @@ const ban = require('./ban');
 module.exports = async (admin, userToWarn, reason) => {
 	const { warns } = await warn(userToWarn, reason);
 
+	const isLastWarn = ', <b>last warning!</b>'
+		.repeat(warns.length === numberOfWarnsToBan - 1);
 
 	const warnMessage = dedent(`
 		⚠️ ${link(admin)} <b>warned</b> ${link(userToWarn)} <b>for</b>:
 
-		${reason} (${warns.length}/${numberOfWarnsToBan})`);
+		${reason} (${warns.length}/${numberOfWarnsToBan}${isLastWarn})`);
 
 	if (warns.length >= numberOfWarnsToBan) {
 		await ban(

--- a/actions/warn.js
+++ b/actions/warn.js
@@ -12,19 +12,23 @@ const ban = require('./ban');
 module.exports = async (admin, userToWarn, reason) => {
 	const { warns } = await warn(userToWarn, reason);
 
-	const replies = [
+
+	const warnMessage =
 		dedent(`⚠️ ${link(admin)} <b>warned</b> ${link(userToWarn)} <b>for</b>:
 
-		${reason} (${warns.length}/${numberOfWarnsToBan})`),
-	];
+		${reason} (${warns.length}/${numberOfWarnsToBan})`);
 
 	if (warns.length >= numberOfWarnsToBan) {
-		replies.push(await ban(
+		await ban(
 			context.botInfo,
 			userToWarn,
 			'Reached max number of warnings'
-		));
+		);
+		return warnMessage +
+			'\n\n' +
+			'🚫 The user was <b>banned</b> ' +
+			`for receiving ${numberOfWarnsToBan} warnings!`;
 	}
 
-	return replies;
+	return warnMessage;
 };

--- a/actions/warn.js
+++ b/actions/warn.js
@@ -9,7 +9,7 @@ const { warn } = require('../stores/user');
 const ban = require('./ban');
 
 
-module.exports = async (admin, userToWarn, reason) => {
+module.exports = async ({ admin, userToWarn, reason }) => {
 	const { warns } = await warn(userToWarn, reason);
 
 	const isLastWarn = ', <b>last warning!</b>'
@@ -21,11 +21,11 @@ module.exports = async (admin, userToWarn, reason) => {
 		${reason} (${warns.length}/${numberOfWarnsToBan}${isLastWarn})`);
 
 	if (warns.length >= numberOfWarnsToBan) {
-		await ban(
-			context.botInfo,
-			userToWarn,
-			'Reached max number of warnings'
-		);
+		await ban({
+			admin: context.botInfo,
+			reason: 'Reached max number of warnings',
+			userToBan: userToWarn,
+		});
 		return warnMessage +
 			'\n\n' +
 			'🚫 The user was <b>banned</b> ' +

--- a/handlers/commands/ban.js
+++ b/handlers/commands/ban.js
@@ -2,15 +2,16 @@
 
 // Utils
 const { link, scheduleDeletion } = require('../../utils/tg');
-const { logError } = require('../../utils/log');
 
 // Bot
 const bot = require('../../bot');
 const { replyOptions } = require('../../bot/options');
 
 // DB
-const { listGroups } = require('../../stores/group');
-const { isAdmin, isBanned, ban } = require('../../stores/user');
+const { isAdmin, isBanned } = require('../../stores/user');
+
+// Actions
+const ban = require('../../actions/ban');
 
 const banHandler = async ({ chat, message, reply, telegram, me, state }) => {
 	const userToBan = message.reply_to_message
@@ -61,22 +62,7 @@ const banHandler = async ({ chat, message, reply, telegram, me, state }) => {
 		);
 	}
 
-	try {
-		await ban(userToBan, reason);
-	} catch (err) {
-		logError(err);
-	}
-
-	const groups = await listGroups();
-
-	const bans = groups.map(group =>
-		telegram.kickChatMember(group.id, userToBan.id));
-
-	try {
-		await Promise.all(bans);
-	} catch (err) {
-		logError(err);
-	}
+	await ban(userToBan, reason);
 
 	if (userToBan.first_name === '') {
 		return reply(`🚫 ${link(state.user)} <b>banned an user with id</b> ` +

--- a/handlers/commands/ban.js
+++ b/handlers/commands/ban.js
@@ -60,7 +60,7 @@ const banHandler = async (ctx) => {
 		);
 	}
 
-	return ban(ctx.from, userToBan, reason).then(ctx.replyWithHTML);
+	return ban({ admin: ctx.from, reason, userToBan }).then(ctx.replyWithHTML);
 };
 
 module.exports = banHandler;

--- a/handlers/commands/warn.js
+++ b/handlers/commands/warn.js
@@ -59,7 +59,7 @@ const warnHandler = async (ctx) => {
 		ctx.deleteMessage(message.reply_to_message.message_id);
 	}
 
-	const warnMessage = await warn(ctx.from, userToWarn, reason);
+	const warnMessage = await warn({ admin: ctx.from, reason, userToWarn });
 
 	return ctx.replyWithHTML(warnMessage, { reply_markup });
 };

--- a/handlers/commands/warn.js
+++ b/handlers/commands/warn.js
@@ -6,27 +6,26 @@ const { logError } = require('../../utils/log');
 
 // Config
 const {
-	numberOfWarnsToBan,
 	warnInlineKeyboard,
 } = require('../../config');
 const reply_markup = { inline_keyboard: warnInlineKeyboard };
 
 // Bot
-const bot = require('../../bot');
 const { replyOptions } = require('../../bot/options');
 
 // DB
-const { isAdmin, ban, getWarns, warn } = require('../../stores/user');
+const { isAdmin } = require('../../stores/user');
+const warn = require('../../actions/warn');
 
-const warnHandler = async ({ message, chat, reply, me, state }) => {
-	const { user } = state;
+const warnHandler = async (ctx) => {
+	const { message, reply, me } = ctx;
 	const userToWarn = message.reply_to_message
 		? Object.assign({ username: '' }, message.reply_to_message.from)
 		: message.commandMention
 			? Object.assign({ username: '' }, message.commandMention)
 			: null;
 
-	if (!state.isAdmin) return null;
+	if (ctx.from.status !== 'admin') return null;
 
 	if (message.chat.type === 'private') {
 		return reply(
@@ -56,42 +55,14 @@ const warnHandler = async ({ message, chat, reply, me, state }) => {
 			.then(scheduleDeletion);
 	}
 
-	await warn(userToWarn, reason);
-	const warnCount = await getWarns(userToWarn);
-	const promises = [];
-
 	if (message.reply_to_message) {
-		promises.push(bot.telegram.deleteMessage(
-			chat.id,
-			message.reply_to_message.message_id
-		));
+		ctx.deleteMessage(message.reply_to_message.message_id);
 	}
 
-	try {
-		await reply(
-			`⚠️ ${link(user)} <b>warned</b> ${link(userToWarn)} <b>for:</b>` +
-			`\n\n${reason} (${warnCount.length}/${numberOfWarnsToBan})`,
-			{ parse_mode: 'HTML', reply_markup }
-		);
-	} catch (e) {
-		// we don't expect an error
-		// but we do wish to continue if one happens
-		// to ban people who reach max number of warnings
-		logError(e);
-	}
+	const replies = await warn(ctx.from, userToWarn, reason);
 
-	if (warnCount.length >= numberOfWarnsToBan) {
-		promises.push(bot.telegram.kickChatMember(chat.id, userToWarn.id));
-		promises.push(ban(userToWarn, 'Reached max number of warnings'));
-		promises.push(reply(
-			`🚫 ${link(user)} <b>banned</b> ${link(userToWarn)} ` +
-			'<b>for:</b>\n\nReached max number of warnings ' +
-			`(${warnCount.length}/${numberOfWarnsToBan})`,
-			replyOptions
-		));
-	}
-
-	return Promise.all(promises).catch(logError);
+	await ctx.replyWithHTML(replies[0], { reply_markup });
+	return replies[1] && ctx.replyWithHTML(replies[1]);
 };
 
 module.exports = warnHandler;

--- a/handlers/commands/warn.js
+++ b/handlers/commands/warn.js
@@ -59,10 +59,9 @@ const warnHandler = async (ctx) => {
 		ctx.deleteMessage(message.reply_to_message.message_id);
 	}
 
-	const replies = await warn(ctx.from, userToWarn, reason);
+	const warnMessage = await warn(ctx.from, userToWarn, reason);
 
-	await ctx.replyWithHTML(replies[0], { reply_markup });
-	return replies[1] && ctx.replyWithHTML(replies[1]);
+	return ctx.replyWithHTML(warnMessage, { reply_markup });
 };
 
 module.exports = warnHandler;

--- a/handlers/messages/removeLinks.js
+++ b/handlers/messages/removeLinks.js
@@ -123,10 +123,9 @@ const removeLinks = async (ctx, next) => {
 		const reason = 'Forwarded or linked channels/groups';
 		ctx.deleteMessage(updateData.message_id);
 
-		const replies = await warn(ctx.botInfo, ctx.from, reason);
+		const warnMessage = await warn(ctx.from, ctx.from, reason);
 
-		await ctx.replyWithHTML(replies[0], { reply_markup });
-		return replies[1] && ctx.replyWithHTML(replies[1]);
+		return ctx.replyWithHTML(warnMessage, { reply_markup });
 	}
 	return next();
 };

--- a/handlers/messages/removeLinks.js
+++ b/handlers/messages/removeLinks.js
@@ -1,27 +1,24 @@
 'use strict';
 
 // Utils
-const { link } = require('../../utils/tg');
 const { logError } = require('../../utils/log');
 
 // Config
 const {
 	excludeLinks,
-	numberOfWarnsToBan,
 	warnInlineKeyboard,
 } = require('../../config');
 const reply_markup = { inline_keyboard: warnInlineKeyboard };
 
 
-// Bot
-const bot = require('../../bot');
-const { replyOptions } = require('../../bot/options');
-
 // DB
-const { ban, warn, getWarns, getUser } = require('../../stores/user');
+const { getUser } = require('../../stores/user');
 const { listGroups } = require('../../stores/group');
 
-const removeLinks = async ({ message, chat, reply, state, update }, next) => {
+const warn = require('../../actions/warn');
+
+const removeLinks = async (ctx, next) => {
+	const { message, state, update } = ctx;
 	const { isAdmin: isStateAdmin, user: stateUser } = state;
 	const user = stateUser ||
 		await getUser({ id: update.edited_message.from.id });
@@ -88,7 +85,7 @@ const removeLinks = async ({ message, chat, reply, state, update }, next) => {
 				.toLowerCase();
 
 			try {
-				const { type } = await bot.telegram.getChat(username);
+				const { type } = await ctx.telegram.getChat(username);
 				if (!type) return false;
 				if (
 					!excludeLinks
@@ -124,37 +121,12 @@ const removeLinks = async ({ message, chat, reply, state, update }, next) => {
 		isAd && isAd.some(item => item)
 	) {
 		const reason = 'Forwarded or linked channels/groups';
-		await warn(user, reason);
-		const warnCount = await getWarns(user);
-		const promises = [
-			bot.telegram.deleteMessage(chat.id, updateData.message_id)
-		];
-		if (warnCount.length < numberOfWarnsToBan) {
-			promises.push(reply(
-				`⚠️ ${link(user)} <b>got warned!</b> ` +
-				`(${warnCount.length}/${numberOfWarnsToBan})` +
-				`\n\nReason: ${reason}`,
-				{ parse_mode: 'HTML', reply_markup }
-			));
-		} else {
-			promises.push(bot.telegram.kickChatMember(chat.id, user.id));
-			promises.push(ban(
-				user,
-				'Reached max number of warnings'
-			));
-			promises.push(reply(
-				`🚫 ${link(user)} <b>got banned</b>! ` +
-				`(${warnCount.length}/${numberOfWarnsToBan})` +
-				'\n\nReason: Reached max number of warnings',
-				replyOptions
-			));
-		}
-		try {
-			await Promise.all(promises);
-		} catch (err) {
-			logError(err);
-		}
-		return next();
+		ctx.deleteMessage(updateData.message_id);
+
+		const replies = await warn(ctx.botInfo, ctx.from, reason);
+
+		await ctx.replyWithHTML(replies[0], { reply_markup });
+		return replies[1] && ctx.replyWithHTML(replies[1]);
 	}
 	return next();
 };

--- a/handlers/messages/removeLinks.js
+++ b/handlers/messages/removeLinks.js
@@ -121,9 +121,11 @@ const removeLinks = async (ctx, next) => {
 		isAd && isAd.some(item => item)
 	) {
 		const reason = 'Forwarded or linked channels/groups';
+		const admin = ctx.botInfo;
+		const userToWarn = ctx.from;
 		ctx.deleteMessage(updateData.message_id);
 
-		const warnMessage = await warn(ctx.from, ctx.from, reason);
+		const warnMessage = await warn({ admin, reason, userToWarn });
 
 		return ctx.replyWithHTML(warnMessage, { reply_markup });
 	}

--- a/stores/user.js
+++ b/stores/user.js
@@ -106,7 +106,11 @@ const isBanned = ({ id }) =>
 		.then(user => user ? user.ban_reason : null);
 
 const warn = ({ id }, reason) =>
-	User.update({ id }, { $push: { warns: reason } });
+	User.update(
+		{ id },
+		{ $push: { warns: reason } },
+		{ returnUpdatedDocs: true }
+	).then(getUpdatedDocument);
 
 const unwarn = ({ id }) =>
 	User.update(


### PR DESCRIPTION
<ins>For future reference, this feature allows any part of the bot to warn and ban, without having to repeat what that means, which reduces duplication and makes the UX more consistent.</ins>

I've tried creating PR from VSCode (Github extension), used wrong command....

**Don't merge it**. I'd prefer to clean up history of this branch, by merge-squashing<del>, or rebasing</del>.

And, since it'll definitely be ~~at least partly~~ squashed, I suggest [reviewing all the changes](https://github.com/thedevs-network/the-guard-bot/pull/54/files) instead of separate commits.

Please review it. Nothing is on develop yet, everything can be improved.

~~Also, signatures of `actions`, are we fine with 3 positional arguments (admin, targetUser, forWhat), or should we switch to options object?~~ <ins>Changed to options object</ins>

The name `actions`, unsure if it's the best.

<ins>If I get no feedback, I'll `merge --squash` this PR tomorrow evening or earlier. This features makes #26 fixable, I'd love to tackle it; ideas how to do it and feedback on [my idea](https://github.com/thedevs-network/the-guard-bot/issues/26#issuecomment-362801682) are welcome.</ins>