### PR TITLE
[ci] Added CircleCI config for continuous integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,4 +21,4 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
         
-      - run: npm run precommit
+      - run: npm run -s lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,24 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10.3
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+        
+      - run: npm run precommit

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "precommit": "bash scripts/pre-commit.sh",
     "start": "node index",
+    "lint": "eslint .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
Runs ESLint on commits once they are pushed to remote.
Would need to set up CircleCI to watch the repo.
It's trivial -- just go to https://github.com/marketplace/circleci
Enable a free plan, and select the repo to watch.