### PR TITLE
Make use of docker layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM node:alpine
 
-
-RUN apk add git
-
 WORKDIR /app
 
 COPY package*.json ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
 FROM node:alpine
 
-COPY . /app
+
+RUN apk add git
+
 WORKDIR /app
 
-RUN apk add git && npm install
+COPY package*.json ./
+
+RUN npm ci --only=production
+
+COPY . .
 
 CMD npm start
-


### PR DESCRIPTION
This will decrease the build times by a massive amount due to layer caching in the docker build process.