### PR TITLE
Hide reporter ID in group and add reportee ID

### DIFF
--- a/handlers/commands/report.js
+++ b/handlers/commands/report.js
@@ -30,7 +30,7 @@ const reportHandler = async ctx => {
 		.filter(isQualified)
 		.map(adminMention);
 	// eslint-disable-next-line max-len
-	const s = TgHtml.tag`❗️ ${link(ctx.from)} <b>reported the message to the admins</b>.${TgHtml.join('', admins)}`;
+	const s = TgHtml.tag`❗️ ${link(ctx.from)} <b>reported the message from ${link(ctx.message.reply_to_message.from)} to the admins</b>.${TgHtml.join('', admins)}`;
 	const report = await ctx.replyWithHTML(s, {
 		reply_to_message_id: ctx.message.reply_to_message.message_id,
 	});
@@ -39,7 +39,7 @@ const reportHandler = async ctx => {
 			chats.report,
 			TgHtml.tag`❗️ ${link(ctx.from)} reported <a href="${msgLink(
 				ctx.message.reply_to_message,
-			)}">a message</a> in ${ctx.chat.title}!`,
+			)}">a message</a> from ${link(ctx.message.reply_to_message.from)} in ${ctx.chat.title}!`,
 			{
 				parse_mode: 'HTML',
 				reply_markup: { inline_keyboard: [ [ {

--- a/handlers/commands/report.js
+++ b/handlers/commands/report.js
@@ -30,7 +30,7 @@ const reportHandler = async ctx => {
 		.filter(isQualified)
 		.map(adminMention);
 	// eslint-disable-next-line max-len
-	const s = TgHtml.tag`❗️ ${link(ctx.from)} <b>reported the message from ${link(ctx.message.reply_to_message.from)} to the admins</b>.${TgHtml.join('', admins)}`;
+	const s = TgHtml.tag`❗️ <b>Message from ${link(ctx.message.reply_to_message.from)} was reported to the admins</b>.${TgHtml.join('', admins)}`;
 	const report = await ctx.replyWithHTML(s, {
 		reply_to_message_id: ctx.message.reply_to_message.message_id,
 	});


### PR DESCRIPTION
Trolls use Telegram Report function on people who report them via bot, sometimes managing to limit them.
This change hides the reportee in the group, but keeps them identified in the admin group.

This change also adds the reportee info to both messages, so it's possible to deal with them in case they delete the message and have no handle.

Before:
![image](https://user-images.githubusercontent.com/1641362/93590562-0794b280-f9af-11ea-9356-7fa90a9ee647.png)
![image](https://user-images.githubusercontent.com/1641362/93590569-0a8fa300-f9af-11ea-84b9-52ec5d6548b5.png)


After:
![image](https://user-images.githubusercontent.com/1641362/93590534-f6e43c80-f9ae-11ea-870b-456406d47b6b.png)
![image](https://user-images.githubusercontent.com/1641362/93590536-f9469680-f9ae-11ea-9bb6-8e32225477ad.png)
