### PR TITLE
Reporting fixes

### DIFF
--- a/handlers/commands/report.js
+++ b/handlers/commands/report.js
@@ -35,6 +35,7 @@ const reportHandler = async ctx => {
 		reply_to_message_id: ctx.message.reply_to_message.message_id,
 	});
 	if (chats.report) {
+		await ctx.deleteMessage();
 		await ctx.tg.sendMessage(
 			chats.report,
 			TgHtml.tag`❗️ ${link(ctx.from)} reported <a href="${msgLink(

--- a/handlers/commands/report.js
+++ b/handlers/commands/report.js
@@ -21,6 +21,8 @@ const adminMention = ({ user }) =>
 /** @param { import('../../typings/context').ExtendedContext } ctx */
 const reportHandler = async ctx => {
 	if (!ctx.chat.type.endsWith('group')) return null;
+	// Ignore monospaced reports
+	if (ctx.message.entities?.[0]?.type === "code" && ctx.message.entities[0].offset === 0) return null;
 	if (!ctx.message.reply_to_message) {
 		return ctx.replyWithHTML(
 			'ℹ️ <b>Reply to message you\'d like to report</b>',

--- a/handlers/regex/index.js
+++ b/handlers/regex/index.js
@@ -5,7 +5,7 @@ const { compose, hears } = require('telegraf');
 /* eslint-disable global-require */
 
 module.exports = compose([
-	hears(/^(?:!report|[@!]admins?)\b/i, require('../commands/report')),
+	hears(/^(?:[/@!](report|admins?))\b/i, require('../commands/report')),
 	require('./runCustomCmd'),
 	require('./groupLinker'),
 ]);


### PR DESCRIPTION
This PR makes it so that all report messages are deleted if there is a report group. 

~~This is a light breaking change, as some people joke with monospaced `/report`, which will now trigger, so such people will likely accidentally trigger a report once before they learn.~~

It also adds /admins and @report as a report command.

This PR also introduces a conflicting /admin, but the current real /admin command takes precedence and no real issue happens.

I hope the guy who snatched @report never joins our groups.

---

Ideally in the report system, the regex should be applied to the message of the reporter and if anything is left over, it should be added as a reason in the admin group, but I'll leave that for another PR some another time.

It is also lost in case the group has a report group.

But we didn't handle reasonings til now and I believe this is more consistent and a step towards the right direction.
