### PR TITLE
Mark old updates with ctx.oldUpdate

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -278,12 +278,6 @@
 		"prefer-rest-params": "warn",
 		"prefer-spread": "warn",
 		"rest-spread-spacing": "error",
-		"sort-imports": [
-			"error",
-			{
-				"ignoreCase": true
-			}
-		],
 		"symbol-description": "error",
 		"template-curly-spacing": "error",
 		"require-atomic-updates": "warn"

--- a/example.config.js
+++ b/example.config.js
@@ -67,7 +67,7 @@ const config = {
 
 	deleteCustom: {
 		longerThan: 450, // UTF-16 characters
-		after: '20 minutes'
+		after: '20 minutes',
 	},
 
 	/**

--- a/handlers/commands/help.js
+++ b/handlers/commands/help.js
@@ -25,8 +25,8 @@ const helpHandler = ({ chat, replyWithHTML }) => {
 	return replyWithHTML(
 		message,
 		Markup.inlineKeyboard([
-			Markup.urlButton('🛠 Setup a New Bot', homepage)
-		]).extra()
+			Markup.urlButton('🛠 Setup a New Bot', homepage),
+		]).extra(),
 	);
 };
 

--- a/handlers/middlewares/index.js
+++ b/handlers/middlewares/index.js
@@ -12,6 +12,7 @@ const composer = new Composer();
 const { deleteAfter } = require('../../utils/tg');
 const { deleteJoinsAfter = '2 minutes' } = require('../../utils/config').config;
 
+const markOldUpdate = require('./markOldUpdate');
 const addedToGroupHandler = require('./addedToGroup');
 const antibotHandler = require('./antibot');
 const checkLinksHandler = require('./checkLinks');
@@ -28,6 +29,7 @@ const syncStatusHandler = require('./syncStatus');
 const updateUserDataHandler = require('./updateUserData');
 const updateGroupTitleHandler = require('./updateGroupTitle');
 
+composer.use(markOldUpdate);
 composer.on('new_chat_members', addedToGroupHandler);
 composer.on('left_chat_member', kickedFromGroupHandler);
 composer.use(leaveUnmanagedHandler);

--- a/handlers/middlewares/logPresence.js
+++ b/handlers/middlewares/logPresence.js
@@ -36,7 +36,7 @@ function log(ctx, next) {
 							],
 						],
 					},
-				}
+				},
 			)
 			.catch(() => null);
 	}

--- a/handlers/middlewares/markOldUpdate.ts
+++ b/handlers/middlewares/markOldUpdate.ts
@@ -1,0 +1,15 @@
+import { Middleware } from "telegraf";
+
+import type { ExtendedContext } from "../../typings/context";
+
+import { botStartTime } from "../../utils/config";
+
+const markOldUpdate: Middleware<ExtendedContext> = (ctx, next) => {
+	const startTime = botStartTime.get().valueOf() / 1000;
+
+	ctx.oldUpdate = Boolean(ctx.message && ctx.message.date < startTime);
+
+	return next();
+};
+
+export = markOldUpdate;

--- a/package-lock.json
+++ b/package-lock.json
@@ -245,14 +245,6 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
-    "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "requires": {
-        "follow-redirects": "1.5.10"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -670,14 +662,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
-    },
-    "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      }
     },
     "form-data": {
       "version": "3.0.0",
@@ -1314,6 +1298,24 @@
       "integrity": "sha512-FaJUYMJKWghyQwXnXS3lznqe76QevuYgU84xhmVO4wVxv96aQvHERnlhu6x6kNVxT/UAGnrR1pYY3XNO6VtaDA==",
       "requires": {
         "axios": "^0.19.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.19.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+          "requires": {
+            "follow-redirects": "1.5.10"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        }
       }
     },
     "sprintf-js": {

--- a/stores/command.js
+++ b/stores/command.js
@@ -16,7 +16,7 @@ const addCommand = command =>
 	Command.update(
 		{ name: command.name },
 		{ $set: { isActive: false, ...command } },
-		{ upsert: true }
+		{ upsert: true },
 	);
 
 const updateCommand = (data) =>

--- a/typings/context.d.ts
+++ b/typings/context.d.ts
@@ -11,6 +11,7 @@ interface DbUser {
 }
 
 export interface ContextExtensions {
+	oldUpdate: boolean;
 	ban(
 		this: ExtendedContext,
 		options: {

--- a/utils/cmd/stringify.js
+++ b/utils/cmd/stringify.js
@@ -19,6 +19,6 @@ exports.stringify = ({ command = '', flags = {}, reason = '' }) => {
 	return [
 		'/' + command,
 		flagS,
-		reason
+		reason,
 	].filter(Boolean).join(' ');
 };

--- a/utils/config.js
+++ b/utils/config.js
@@ -1,12 +1,13 @@
 // @ts-check
 'use strict';
 
+const ms = require('millisecond');
+
 /** @type { import('../typings/config').Config } */
 // @ts-ignore
 const config = require('../config');
 const eq = require('./eq');
-
-const ms = require('millisecond');
+const { throwError } = require('./errors');
 
 const { expireWarnsAfter = Infinity } = config;
 
@@ -31,8 +32,26 @@ const isMaster = user =>
 		user.id === Number(x) ||
 		user.username && eq.username(user.username, String(x)));
 
+/**
+ * A getter/setter pair for botStartTime
+ * @type {{
+ * 	get: () => Date;
+ * 	set: (date: Date) => Date
+ * }}
+ */
+const botStartTime = (() => {
+	let time;
+	return {
+		get: () => time,
+		set: (date) => time
+			? throwError('botStartTime cannot be set twice.')
+			: time = date,
+	};
+})();
+
 module.exports = {
 	config,
 	isMaster,
 	isWarnNotExpired,
+	botStartTime,
 };

--- a/utils/errors.ts
+++ b/utils/errors.ts
@@ -1,0 +1,10 @@
+/* eslint-disable no-console */
+
+export const throwError = (e: string | Error) => {
+	if (typeof e === "string") throw new Error(e);
+	else throw e;
+};
+
+export const panic = (e: Error, ...msgs: string[]) => (
+	console.error(...msgs), throwError(e)
+);

--- a/utils/log.js
+++ b/utils/log.js
@@ -12,5 +12,5 @@ const print = value =>
 
 module.exports = {
 	logError,
-	print
+	print,
 };


### PR DESCRIPTION
* Hits Telegram's `getMe` endpoint on bot start, before `bot.launch()`
* Stores the date header of `getMe`'s response
* Marks any update older than the stored date with `ctx.oldUpdate = true`, otherwise `false`

Useful for plugins that don't want to retroactively act on old updates if bot was down