### PR TITLE
Fix /addcommand, /help, comment typo and add 'UTC' string to timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Command                 | Role       | Available at | Description
 `/ban <reason>`         | _Admin_    | _Groups_     | Bans the user from groups.
 `/unban`                | _Admin_    | _Everywhere_ | Removes the user from ban list.
 `/user`                 | _Admin_    | _Everywhere_ | Shows the status of the user.
-`/addcommand <name>`    | _Admin_    | _In-Bot_     | Create a custom command.
+`/addcommand <name>`    | _Admin_    | _In-Bot_     | Create a custom command. Message used to add the command must not be deleted. Optional -replace flag.
 `/removecommand <name>` | _Admin_    | _In-Bot_     | Remove a custom command.
 `/staff`                | _Everyone_ | _Everywhere_ | Shows a list of admins.
 `/link`                 | _Everyone_ | _Everywhere_ | Shows the current group's link.
@@ -82,7 +82,7 @@ If used by reply, `/ban` and `/warn` would remove the replied-to message.
 ## Plugins
 
 The guard is extensible in form of plugins where custom features and commands can be easily added to it. To use a plugin, put it in the [/plugins](/plugins) directory and add its name to plugins array in config.js.
-Checkout our [Plugins' Wiki](https://github.com/thedevs-network/the-guard-bot/wiki/Plugins) page for more information. 
+Checkout our [Plugins' Wiki](https://github.com/thedevs-network/the-guard-bot/wiki/Plugins) page for more information.
 
 **Known plugins**:
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Command                 | Role       | Available at | Description
 `/ban <reason>`         | _Admin_    | _Groups_     | Bans the user from groups.
 `/unban`                | _Admin_    | _Everywhere_ | Removes the user from ban list.
 `/user`                 | _Admin_    | _Everywhere_ | Shows the status of the user.
-`/addcommand <name>`    | _Admin_    | _In-Bot_     | Create a custom command. Message used to add the command must not be deleted. Optional -replace flag.
+`/addcommand <name>`    | _Admin_    | _In-Bot_     | Create a custom command.
 `/removecommand <name>` | _Admin_    | _In-Bot_     | Remove a custom command.
 `/staff`                | _Everyone_ | _Everywhere_ | Shows a list of admins.
 `/link`                 | _Everyone_ | _Everywhere_ | Shows the current group's link.
@@ -82,7 +82,7 @@ If used by reply, `/ban` and `/warn` would remove the replied-to message.
 ## Plugins
 
 The guard is extensible in form of plugins where custom features and commands can be easily added to it. To use a plugin, put it in the [/plugins](/plugins) directory and add its name to plugins array in config.js.
-Checkout our [Plugins' Wiki](https://github.com/thedevs-network/the-guard-bot/wiki/Plugins) page for more information.
+Checkout our [Plugins' Wiki](https://github.com/thedevs-network/the-guard-bot/wiki/Plugins) page for more information. 
 
 **Known plugins**:
 

--- a/bot/index.js
+++ b/bot/index.js
@@ -18,7 +18,7 @@ if (process.env.NODE_ENV === 'development') {
 
 module.exports = bot;
 
-// Elsewhere the bot can't ban on reaching max warns due to botInfo not being available to get its admin ID
+// Otherwise the bot can't ban on reaching max warns due to botInfo not being available to get its admin ID
 Object.defineProperty(bot.context, "botInfo", {
   get () { return bot.botInfo; }
 })

--- a/bot/index.js
+++ b/bot/index.js
@@ -18,7 +18,7 @@ if (process.env.NODE_ENV === 'development') {
 
 module.exports = bot;
 
-// Otherwise the bot can't ban on reaching max warns due to botInfo not being available to get its admin ID
+// Elsewhere the bot can't ban on reaching max warns due to botInfo not being available to get its admin ID
 Object.defineProperty(bot.context, "botInfo", {
   get () { return bot.botInfo; }
 })

--- a/handlers/commands/addCommand.js
+++ b/handlers/commands/addCommand.js
@@ -83,8 +83,7 @@ const addCommandHandler = async (ctx) => {
 			Markup.keyboard([ [ `/addcommand -replace ${newCommand}` ] ])
 				.selective()
 				.oneTime()
-				.resize()
-				.extra(),
+				.resize(),
 		);
 	}
 	if (cmdExists && cmdExists.role === 'master' && !isMaster(ctx.from)) {

--- a/handlers/commands/help.js
+++ b/handlers/commands/help.js
@@ -25,8 +25,8 @@ const helpHandler = (ctx) => {
 	return ctx.replyWithHTML(
 		message,
 		Markup.inlineKeyboard([
-			Markup.urlButton('🛠 Setup a New Bot', homepage)
-		]).extra()
+			Markup.button.url('🛠 Setup a New Bot', homepage)
+		])
 	);
 };
 

--- a/handlers/commands/user.js
+++ b/handlers/commands/user.js
@@ -13,7 +13,7 @@ const { getUser, permit } = require('../../stores/user');
 
 /** @param {Date} date */
 const formatDate = date =>
-	date && date.toISOString().slice(0, -5).replace('T', ' ');
+	date && date.toISOString().slice(0, -5).replace('T', ' ') + ' UTC';
 
 /**
  * @param {string} defaultVal


### PR DESCRIPTION
Commands broke due to Telegraf 4 migration
timestamps are always shown in UTC, but the timezone is not mentioned, which is confusing.