### PR TITLE
WIP config: add telegram id to excluded links in the config example

### DIFF
--- a/example.config.js
+++ b/example.config.js
@@ -110,8 +110,10 @@ const config = {
 	 * List of whitelisted links and usernames,
 	 * For channels and groups to stop warning users for them.
 	 * Pass false to whitelist all links and channels.
+	 * 777000 is the ID of Telegram. Keep it if you want to allow forwards from Telegram,
+	 * 	this allows channel posts to be forwarded when you link a channel for discussions.
 	 */
-	excludeLinks: [],
+	excludeLinks: [777000],
 
 	/**
 	 * @type {ms}


### PR DESCRIPTION
I think this should be the default behavior, to allow channel discussions (comments) work.