### PR TITLE
fix: keep auto forwarded channel posts to its linked discussion group

### DIFF
--- a/handlers/middlewares/removeChannelForwards.js
+++ b/handlers/middlewares/removeChannelForwards.js
@@ -52,6 +52,10 @@ const handler = async (ctx, next) => {
 		return next();
 	}
 
+	if (ctx.message?.is_automatic_forward) {
+		return next();
+	}
+
 	ctx.deleteMessage().catch(() => null);
 	return ctx.warn({
 		admin: ctx.botInfo,


### PR DESCRIPTION
Ignore forwards checks if the message is automatically forwarded from channel to its linked discussion group.