### PR TITLE
Deps bump

### DIFF
--- a/handlers/middlewares/checkLinks.ts
+++ b/handlers/middlewares/checkLinks.ts
@@ -67,7 +67,7 @@ const actionPriority = (action: Action) => action.type;
 const maxByActionPriority = R.maxBy(actionPriority);
 const highestPriorityAction = R.reduce(maxByActionPriority, Action.Nothing);
 
-const assumeProtocol = R.unless(R.contains("://"), R.concat("http://"));
+const assumeProtocol = R.unless(R.includes("://"), R.concat("http://"));
 const isHttp = R.propSatisfies(R.test(/^https?:$/i), "protocol");
 const isLink = (entity: MessageEntity) =>
 	["url", "text_link", "mention"].includes(entity.type);
@@ -162,7 +162,9 @@ const checkLinkByDomain = (url: URL) => {
 	return handler(url);
 };
 
-const classifyAsync = R.memoize(async (url: URL) => {
+const urlToKey = (url: URL) => url.toString();
+
+const classifyAsync = R.memoizeWith(urlToKey, async (url: URL) => {
 	if (isWhitelisted(url)) return Action.Nothing;
 
 	if (blacklisted.protocol(url)) return Action.Warn("Link using tg protocol");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,27 +1,27 @@
 {
   "name": "the_guard_bot",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "the_guard_bot",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "dedent-js": "^1.0.1",
         "jspack": "0.0.4",
         "millisecond": "^0.1.2",
         "nedb-promise": "^2.0.1",
-        "ramda": "^0.25.0",
+        "ramda": "^0.29.0",
         "require-directory": "^2.1.1",
         "spamwatch": "^0.4.0",
         "string-replace-async": "^2.0.0",
-        "telegraf": "^4.8.3",
-        "ts-node": "^10.7.0",
-        "typescript": "^4.6.3",
-        "undici": "^4.16.0",
-        "xregexp": "^5.1.0"
+        "telegraf": "^4.13.1",
+        "ts-node": "^10.9.1",
+        "typescript": "^5.2.2",
+        "undici": "^5.24.0",
+        "xregexp": "^5.1.1"
       },
       "devDependencies": {
         "@types/node": "^13.13.2",
@@ -36,7 +36,7 @@
         "prettier": "2.0.5"
       },
       "engines": {
-        "node": ">=12.20.2"
+        "node": ">=18.17.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -118,6 +118,11 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@telegraf/types": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@telegraf/types/-/types-6.8.1.tgz",
+      "integrity": "sha512-JCRQuPPDCreYQaAeOwnqIlWrs8pJVvaNEUWBVNvdK3oJoTUKyBV+3TsPrIcnGqLeapptznuTk5s4udTlZPvGTA=="
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
@@ -480,6 +485,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
       "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -1496,10 +1512,13 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/module-alias": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
-      "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -1546,9 +1565,9 @@
       "dev": true
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -1704,9 +1723,13 @@
       }
     },
     "node_modules/ramda": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
-      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
+      "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.9",
@@ -1889,6 +1912,14 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string-replace-async": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-replace-async/-/string-replace-async-2.0.0.tgz",
@@ -2013,22 +2044,21 @@
       }
     },
     "node_modules/telegraf": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.8.3.tgz",
-      "integrity": "sha512-B3gcxoYU+ZTzdvmubvTmsOy/ytOWUEzr3VxtSGCODnwuGruWUCgv60NRFIBGmKxk23OT9aSrW+5F5T4OeyCOMQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.13.1.tgz",
+      "integrity": "sha512-WXITwqE3ivqDqjHFxj94xaQhHddldBZdE2g/hRJXyCMTkwZYw69q9I7La7nsDpsHLn5ADSQlGv0KAbwFkFpmlA==",
       "dependencies": {
+        "@telegraf/types": "^6.8.1",
         "abort-controller": "^3.0.0",
-        "debug": "^4.3.3",
-        "minimist": "^1.2.6",
-        "module-alias": "^2.2.2",
-        "node-fetch": "^2.6.7",
+        "debug": "^4.3.4",
+        "mri": "^1.2.0",
+        "node-fetch": "^2.6.8",
         "p-timeout": "^4.1.0",
         "safe-compare": "^1.1.4",
-        "sandwich-stream": "^2.0.2",
-        "typegram": "^3.9.0"
+        "sandwich-stream": "^2.0.2"
       },
       "bin": {
-        "telegraf": "bin/telegraf"
+        "telegraf": "lib/cli.mjs"
       },
       "engines": {
         "node": "^12.20.0 || >=14.13.1"
@@ -2069,12 +2099,12 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/ts-node": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-      "integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -2166,21 +2196,16 @@
         "node": ">=8"
       }
     },
-    "node_modules/typegram": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.9.1.tgz",
-      "integrity": "sha512-vfFr2o0iX+amnUj1h/0c49y8bCvGwt6DgdmTVD732Kf81XG26vgFwNWj+33Ol+xORC7m0cqU2hPYGRtcGinwZg=="
-    },
     "node_modules/typescript": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
-      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/underscore": {
@@ -2189,11 +2214,14 @@
       "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
     },
     "node_modules/undici": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.16.0.tgz",
-      "integrity": "sha512-tkZSECUYi+/T1i4u+4+lwZmQgLXd4BLGlrc7KZPcLIW7Jpq99+Xpc30ONv7nS6F5UNOxp/HBZSSL9MafUrvJbw==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.24.0.tgz",
+      "integrity": "sha512-OKlckxBjFl0oXxcj9FU6oB8fDAaiRUq+D8jrFWGmOfI/gIyjk/IeS75LMzgYKUaeHzLUcYvf9bbJGSrUwTfwwQ==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
       "engines": {
-        "node": ">=12.18"
+        "node": ">=14.0"
       }
     },
     "node_modules/uri-js": {
@@ -2219,12 +2247,12 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -2270,11 +2298,11 @@
       }
     },
     "node_modules/xregexp": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.0.tgz",
-      "integrity": "sha512-PynwUWtXnSZr8tpQlDPMZfPTyv78EYuA4oI959ukxcQ0a9O/lvndLVKy5wpImzzA26eMxpZmnAXJYiQA13AtWA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.1.tgz",
+      "integrity": "sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==",
       "dependencies": {
-        "@babel/runtime-corejs3": "^7.14.9"
+        "@babel/runtime-corejs3": "^7.16.5"
       }
     },
     "node_modules/yallist": {
@@ -2354,6 +2382,11 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "@telegraf/types": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@telegraf/types/-/types-6.8.1.tgz",
+      "integrity": "sha512-JCRQuPPDCreYQaAeOwnqIlWrs8pJVvaNEUWBVNvdK3oJoTUKyBV+3TsPrIcnGqLeapptznuTk5s4udTlZPvGTA=="
     },
     "@tsconfig/node10": {
       "version": "1.0.8",
@@ -2624,6 +2657,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
       "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
     },
     "callsites": {
       "version": "3.1.0",
@@ -3407,10 +3448,10 @@
         "minimist": "^1.2.6"
       }
     },
-    "module-alias": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.2.tgz",
-      "integrity": "sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q=="
+    "mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
     },
     "ms": {
       "version": "2.1.2",
@@ -3457,9 +3498,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -3562,9 +3603,9 @@
       "dev": true
     },
     "ramda": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
-      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.29.0.tgz",
+      "integrity": "sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA=="
     },
     "regenerator-runtime": {
       "version": "0.13.9",
@@ -3704,6 +3745,11 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
     "string-replace-async": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-replace-async/-/string-replace-async-2.0.0.tgz",
@@ -3799,19 +3845,18 @@
       }
     },
     "telegraf": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.8.3.tgz",
-      "integrity": "sha512-B3gcxoYU+ZTzdvmubvTmsOy/ytOWUEzr3VxtSGCODnwuGruWUCgv60NRFIBGmKxk23OT9aSrW+5F5T4OeyCOMQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.13.1.tgz",
+      "integrity": "sha512-WXITwqE3ivqDqjHFxj94xaQhHddldBZdE2g/hRJXyCMTkwZYw69q9I7La7nsDpsHLn5ADSQlGv0KAbwFkFpmlA==",
       "requires": {
+        "@telegraf/types": "^6.8.1",
         "abort-controller": "^3.0.0",
-        "debug": "^4.3.3",
-        "minimist": "^1.2.6",
-        "module-alias": "^2.2.2",
-        "node-fetch": "^2.6.7",
+        "debug": "^4.3.4",
+        "mri": "^1.2.0",
+        "node-fetch": "^2.6.8",
         "p-timeout": "^4.1.0",
         "safe-compare": "^1.1.4",
-        "sandwich-stream": "^2.0.2",
-        "typegram": "^3.9.0"
+        "sandwich-stream": "^2.0.2"
       }
     },
     "text-table": {
@@ -3846,12 +3891,12 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "ts-node": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.0.tgz",
-      "integrity": "sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -3905,15 +3950,10 @@
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
     },
-    "typegram": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/typegram/-/typegram-3.9.1.tgz",
-      "integrity": "sha512-vfFr2o0iX+amnUj1h/0c49y8bCvGwt6DgdmTVD732Kf81XG26vgFwNWj+33Ol+xORC7m0cqU2hPYGRtcGinwZg=="
-    },
     "typescript": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
-      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A=="
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
     },
     "underscore": {
       "version": "1.4.4",
@@ -3921,9 +3961,12 @@
       "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
     },
     "undici": {
-      "version": "4.16.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.16.0.tgz",
-      "integrity": "sha512-tkZSECUYi+/T1i4u+4+lwZmQgLXd4BLGlrc7KZPcLIW7Jpq99+Xpc30ONv7nS6F5UNOxp/HBZSSL9MafUrvJbw=="
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.24.0.tgz",
+      "integrity": "sha512-OKlckxBjFl0oXxcj9FU6oB8fDAaiRUq+D8jrFWGmOfI/gIyjk/IeS75LMzgYKUaeHzLUcYvf9bbJGSrUwTfwwQ==",
+      "requires": {
+        "busboy": "^1.6.0"
+      }
     },
     "uri-js": {
       "version": "4.4.1",
@@ -3948,12 +3991,12 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -3990,11 +4033,11 @@
       }
     },
     "xregexp": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.0.tgz",
-      "integrity": "sha512-PynwUWtXnSZr8tpQlDPMZfPTyv78EYuA4oI959ukxcQ0a9O/lvndLVKy5wpImzzA26eMxpZmnAXJYiQA13AtWA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.1.tgz",
+      "integrity": "sha512-fKXeVorD+CzWvFs7VBuKTYIW63YD1e1osxwQ8caZ6o1jg6pDAbABDG54LCIq0j5cy7PjRvGIq6sef9DYPXpncg==",
       "requires": {
-        "@babel/runtime-corejs3": "^7.14.9"
+        "@babel/runtime-corejs3": "^7.16.5"
       }
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the_guard_bot",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Telegram guard bot to manage a network of groups.",
   "main": "index.js",
   "scripts": {
@@ -37,18 +37,18 @@
     "jspack": "0.0.4",
     "millisecond": "^0.1.2",
     "nedb-promise": "^2.0.1",
-    "ramda": "^0.25.0",
+    "ramda": "^0.29.0",
     "require-directory": "^2.1.1",
     "spamwatch": "^0.4.0",
     "string-replace-async": "^2.0.0",
-    "telegraf": "^4.8.3",
-    "ts-node": "^10.7.0",
-    "typescript": "^4.6.3",
-    "undici": "^4.16.0",
-    "xregexp": "^5.1.0"
+    "telegraf": "^4.13.1",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.2.2",
+    "undici": "^5.24.0",
+    "xregexp": "^5.1.1"
   },
   "engines": {
-    "node": ">=12.20.2"
+    "node": ">=18.17.1"
   },
   "devDependencies": {
     "@types/node": "^13.13.2",

--- a/stores/user.js
+++ b/stores/user.js
@@ -38,7 +38,7 @@ User.update(
 const normalizeTgUser = R.pipe(
 	R.pick([ 'first_name', 'id', 'last_name', 'username' ]),
 	R.evolve({ username: R.toLower }),
-	R.merge({ first_name: '', last_name: '' }),
+	R.mergeRight({ first_name: '', last_name: '' }),
 );
 
 const getUpdatedDocument = R.prop(1);


### PR DESCRIPTION
Bump version to 1.5.0
Bump minimum node to latest supported LTS (12->18) Bump all possible deps, notably Telegraf to 4.13

string-replace-async and nedb-promise still need to be dealt with later.