### PR TITLE
Admin log fixes

### DIFF
--- a/bot/context.js
+++ b/bot/context.js
@@ -38,10 +38,10 @@ module.exports = {
 
 	loggedReply(html, extra) {
 		if (chats.adminLog) {
-			this.tg
+			this.telegram
 				.sendMessage(
 					chats.adminLog,
-					html.toJSON().replace(/\[<code>(\d+)<\/code>\]/g, '[#u$1]'),
+					html,
 					{ parse_mode: 'HTML' },
 				)
 				.catch(() => null);

--- a/example.config.js
+++ b/example.config.js
@@ -42,6 +42,12 @@ const config = {
 
 
 	chats: {
+		/**
+		 * @type {(number | false)}
+		 * Chat to send member (un)ban/(un)warn/report notifications and relevant messages to.
+		 * Pass false to disable this feature.
+		 */
+		adminLog: false,
 
 		/**
 		 * @type {(number | false)}

--- a/handlers/commands/ban.js
+++ b/handlers/commands/ban.js
@@ -4,6 +4,7 @@
 const { displayUser, scheduleDeletion } = require('../../utils/tg');
 const { html } = require('../../utils/html');
 const { parse, strip, substom } = require('../../utils/cmd');
+const { chats = {} } = require('../../utils/config').config;
 
 // Bot
 
@@ -53,6 +54,9 @@ const banHandler = async (ctx) => {
 	}
 
 	if (ctx.message.reply_to_message) {
+		if (chats.adminLog) {
+			await ctx.telegram.forwardMessage(chats.adminLog, ctx.message.chat.id, ctx.message.reply_to_message.message_id)
+		}
 		ctx.deleteMessage(ctx.message.reply_to_message.message_id)
 			.catch(() => null);
 	}

--- a/handlers/commands/leave.ts
+++ b/handlers/commands/leave.ts
@@ -11,7 +11,7 @@ const leaveCommandHandler = async (ctx: ExtendedContext) => {
 	const group = query
 		? await managesGroup(
 				/^-?\d+/.test(query) ? { id: +query } : { title: query }
-		  )
+			)
 		: ctx.chat;
 	if (!group) {
 		return ctx.replyWithHTML("❓ <b>Unknown group.</b>");

--- a/handlers/commands/report.js
+++ b/handlers/commands/report.js
@@ -3,13 +3,13 @@
 // Utils
 const Cmd = require('../../utils/cmd');
 const { TgHtml } = require('../../utils/html');
+const { chats = {} } = require('../../utils/config').config;
 const {
 	link,
 	msgLink,
 	scheduleDeletion,
 } = require('../../utils/tg');
 
-const { chats = {} } = require('../../utils/config').config;
 
 const isQualified = member => member.status === 'creator' ||
 	member.can_delete_messages &&
@@ -27,7 +27,7 @@ const reportHandler = async ctx => {
 	if (!ctx.message.reply_to_message) {
 		await ctx.deleteMessage();
 		return ctx.replyWithHTML(
-			'ℹ️ <b>Reply to message you\'d like to report</b>',
+			'ℹ️ <b>Reply to the message you\'d like to report</b>',
 		).then(scheduleDeletion());
 	}
 	const admins = (await ctx.getChatAdministrators())
@@ -58,6 +58,18 @@ const reportHandler = async ctx => {
 						reason: 'Report handled',
 					}),
 				} ] ] } },
+		);
+	}
+	if (chats.adminLog) {
+		await ctx.telegram.forwardMessage(chats.adminLog, ctx.message.chat.id, ctx.message.reply_to_message.message_id)
+		await ctx.telegram.sendMessage(
+			chats.adminLog,
+			TgHtml.tag`❗️ ${link(ctx.from)} reported <a href="${msgLink(
+				ctx.message.reply_to_message,
+			)}">a message</a> from ${link(ctx.message.reply_to_message.from)} in ${ctx.chat.title}!`,
+			{
+				parse_mode: 'HTML'
+			},
 		);
 	}
 	return null;

--- a/handlers/commands/warn.js
+++ b/handlers/commands/warn.js
@@ -3,6 +3,7 @@
 // Utils
 const { parse, strip, substom } = require('../../utils/cmd');
 const { scheduleDeletion } = require('../../utils/tg');
+const { chats = {} } = require('../../utils/config').config;
 
 // DB
 const { getUser } = require('../../stores/user');
@@ -46,6 +47,9 @@ const warnHandler = async (ctx) => {
 	}
 
 	if (ctx.message.reply_to_message) {
+		if (chats.adminLog) {
+			await ctx.telegram.forwardMessage(chats.adminLog, ctx.message.chat.id, ctx.message.reply_to_message.message_id)
+		}
 		ctx.deleteMessage(ctx.message.reply_to_message.message_id)
 			.catch(() => null);
 	}

--- a/handlers/middlewares/commandButtons.js
+++ b/handlers/middlewares/commandButtons.js
@@ -20,7 +20,7 @@ module.exports = (ctx, next) => {
 	};
 
 	/** @type { import('../../typings/context').ExtendedContext } */
-	const cbCtx = new Context(cbUpdate, ctx.tg, ctx.options);
+	const cbCtx = new Context(cbUpdate, ctx.telegram, ctx.options);
 	Object.assign(cbCtx, contextCustomizations);
 	cbCtx.botInfo = ctx.botInfo;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "the_guard_bot",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Telegram guard bot to manage a network of groups.",
   "main": "index.js",
   "scripts": {

--- a/typings/config.d.ts
+++ b/typings/config.d.ts
@@ -24,8 +24,9 @@ export interface Config {
 	chats?: {
 		/**
 		 * Chat to log all admin actions to.
+		 * Pass false to disable this feature.
 		 */
-		adminLog?: number;
+		adminLog?: number | false;
 
 		/**
 		 * Chat to send member join/leave notifications to.


### PR DESCRIPTION
Fixes https://github.com/thedevs-network/the-guard-bot/issues/144

Add adminLog to example config
Also log messages that were being replied to in ban/warn/report

Removes weird regex that was causing a weird `#u` issue in adminLog
![image](https://github.com/thedevs-network/the-guard-bot/assets/1641362/2b3121f6-4e6f-47a8-bd0b-0a212316cacf)
